### PR TITLE
Using alternate sysfs entries of the ACPI Battery Driver (and others?).

### DIFF
--- a/battery-widget.lua
+++ b/battery-widget.lua
@@ -76,19 +76,56 @@ function battery_widget.new(args)
     return sw
 end
 
+local sysfs_names = {
+    charging = {
+        present   = "present",
+        state     = "status",
+        rate      = "current_now",
+        charge    = "charge_now",
+        capacity  = "charge_full",
+        design    = "charge_full_design",
+        ac_state  = "AC/online",
+        percent   = "capacity",
+    },
+    discharging = {
+        present   = "present",
+        state     = "status",
+        rate      = "power_now",
+        charge    = "energy_now",
+        capacity  = "energy_full",
+        design    = "energy_full_design",
+        ac_state  = "AC/online",
+        percent   = "capacity"
+    }
+}
+
 function battery_widget:get_state()
     local present, capacity, state, rate, charge
     local percent, time, is_charging
 
     local pre = "/sys/class/power_supply/"
     local dir = pre .. self.adapter
-    present   = readfile(dir.."/present")
-    state     = trim(readfile(dir.."/status"):lower())
-    rate      = readfile(dir.."/power_now")
-    charge    = readfile(dir.."/energy_now")
-    capacity  = readfile(dir.."/energy_full")
-    design    = readfile(dir.."/energy_full_design")
-    ac_state  = readfile(pre.."/AC/online")
+
+    local sysfs = sysfs_names.charging
+
+    present   = readfile(dir.."/"..sysfs.present)
+    state     = trim(readfile(dir.."/"..sysfs.state):lower())
+
+    -- avoid failing for each file that might be found under another name.
+    rate      = readfile(dir.."/"..sysfs.rate)
+    if rate == nil then
+        sysfs = sysfs_names.discharging
+        rate  = readfile(dir.."/"..sysfs.rate)
+        if rate == nil then
+            print("Error: no known sysfs files in " .. dir ".")
+        end
+    end
+
+    charge    = readfile(dir.."/"..sysfs.charge)
+    capacity  = readfile(dir.."/"..sysfs.capacity)
+    design    = readfile(dir.."/"..sysfs.design)
+    ac_state  = readfile(pre.."/"..sysfs.ac_state)
+    percent   = readfile(dir.."/"..sysfs.percent)
 
     if state == "unknown" then
         state = "charged"
@@ -98,10 +135,10 @@ function battery_widget:get_state()
     rate     = tonumber(rate)
     charge   = tonumber(charge)
     capacity = tonumber(capacity)
+    percent  = tonumber(percent)
 
     -- loaded percentage
-    percent = nil
-    if charge ~= nil and capacity ~= nil then
+    if percentage == nil and charge ~= nil and capacity ~= nil then
         percent = round(charge * 100 / capacity)
     end
 


### PR DESCRIPTION
In case the sysfs entries are created when the battery is fully charged and AC is present, some entries are prefixed with 'energy_' instead of 'charge_' and might contain values of another unit.

According to the driver's code, these entries contain the same values in the same unit (see http://lxr.free-electrons.com/source/drivers/acpi/battery.c#L197).
A comment in power_supply.h (http://lxr.free-electrons.com/source/include/linux/power_supply.h#L23) suggests that other drivers might more correctly return energies in µWh and charges in µAh. As long as consistent units are used, this does not affect the time / percentage calculations.
Furthermore, this patch uses the percentage value exposed in the sysfs instead of calculating it, if available.

This patch assumes, that if either of the filenames is used, all remaining entries will follow the same naming scheme.

All my laptops use the ACPI driver, so I could not double check, if it works with other drivers. But according to the kernel code I checked, it will probably work.