### PR TITLE
Customizable widget text

### DIFF
--- a/battery-widget.lua
+++ b/battery-widget.lua
@@ -142,6 +142,9 @@ function battery_widget:update()
       for k,v in ipairs(self.limits) do
           if percent <= v[1] then
               text = fg(v[2], text)
+              if ac_state ~= 1 and v[3] ~= nil then
+                  prefix = v[3]
+              end
               break
           end
       end

--- a/battery-widget.lua
+++ b/battery-widget.lua
@@ -56,6 +56,8 @@ function battery_widget:init(args)
         {50, "orange"},
         {100, "green"}
     }
+    self.widget_prefix = args.widget_prefix or ""
+    self.widget_suffix = args.widget_suffix or ""
 
     self.widget = wibox.widget.textbox()
     self.widget.set_align("right")
@@ -161,7 +163,11 @@ function battery_widget:update()
 
 
     -- update text
-    self.widget:set_markup(prefix..text)
+    self.widget:set_markup(
+            self.widget_prefix
+            .. prefix .. text
+            .. self.widget_suffix
+        )
 
     -- capacity text
     if capacity ~= nil and design ~= nil then


### PR DESCRIPTION
Added more options to customize the text displayed by the widget.

**Added optional pre-/suffix to separate the widget from others.**
This allows users to add a custom pre- and/or suffix to the widget's text.
In case multiple widgets are used, this helps to visually separate them.


**Optionally changing the battery_prefix with charge.**
Added an optional element to the 'limits' list, that allows the battery icon
to change with changing charges (percentages), just like it the text
color.

In order not to break existing configurations, the 'battery_prefix' value is not
removed and the additional list element is optional.