### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,34 @@ right_layout:add(battery.widget)
 ...
 ```
 
+If you have multiple batteries or use the same `rc.lua` on multiple devices with differing numbers of batteries:
+```lua
+...
+-- creates an empty container wibox, which can be added to your panel even if its empty
+batteries={layout=wibox.layout.fixed.horizontal}
+    -- searches for batteries on the actual device
+    local batteries_found = io.popen("find /sys/class/power_supply -mindepth 1 -maxdepth 1  -regex '.*BAT.*'|sed 's_.*/__g'")
+    while true do
+      local bat = batteries_found:read()
+      if not bat then break end
+      table.insert(batteries, battery_widget({adapter = bat}))
+    end
+...
+-- add 'batteries' to the widget container
+s.mywibox:setup {
+layout = wibox.layout.align.horizontal,
+    { -- Left widgets
+        ...,
+    },
+    ...,
+    { -- Right widgets
+        ...,
+        batteries,
+    },
+}
+...
+```
+
 ### Usage Options
 
 ```lua


### PR DESCRIPTION
Added a way of automating the detection of batteries, for using the same rc.lua on multiple devices wich might have 0 to n batteries. I happen to own a thinkpad, which indeed has two batteries installed, but I also want my config to work on my main pc, which has zero batteries. To achieve this I came up with this little snippet, which by the way is more compatible with the actual awesome wm default `rc.lua`.