### PR TITLE
Handle non existent battery

### DIFF
--- a/battery-widget.lua
+++ b/battery-widget.lua
@@ -159,7 +159,7 @@ function battery_widget:get_state()
                    or sysfs_names.discharging)
 
     local function read_trim(filename)
-        return trim(readfile(filename))
+        return trim(readfile(filename)) or ""
     end
 
     -- If there is no battery on this machine.


### PR DESCRIPTION
This patch allows the instantiation of a battery widget with an non-existent adapter. For instance some laptops have multiple battery slots which are not connected all the time.