### PR TITLE
Allow setting different battery prefixes at different percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ battery_widget {
     adapter = "BAT0",
     ac_prefix = "AC: ",
     battery_prefix = "Bat: ",
-    limits = {
+    percent_colors = {
         { 25, "red"   },
         { 50, "orange"},
         {100, "green" }
@@ -97,9 +97,9 @@ The pointer located inside of `/sys/class/power_supply` which corresponds to you
 The prefix to populate `${AC_BAT}` when your computer is using ac power. If your font supports unicode characters, you could use "🔌".
 
 `battery_prefix`
-The prefix to populate `${AC_BAT}` when your computer is using battery power. If your font supports unicode characters, you could use "🔋". Can also be configured as a table like `limits` to show different prefixes at different battery percentages.
+The prefix to populate `${AC_BAT}` when your computer is using battery power. If your font supports unicode characters, you could use "🔋". Can also be configured as a table like `percent_colors` to show different prefixes at different battery percentages.
 
-`limits`
+`percent_colors` (`limits` for backwards compatibility)
 The colors that the percentage changes to, as well as the upper-bound limit of when it will change. Ex. `{100, "green"}` means any percentage lower than 100 is colored green.
 
 `listen`
@@ -126,7 +126,32 @@ The text which shows up on the alert notification, respectively the title and bo
 `warn_full_battery`, boolean
 Whether a notification should be displayed when the battery gets fully charged
 
-The text elements `ac_prefix`, `battery_prefix`, and `widget_text` can be further customised with spans, e.g.:
+### Usage Examples
+
+Percentage tables can be used for `ac_prefix`, `battery_prefix`, and `percent_colors` to show different things depending on the battery charge level, e.g.:
+
+```lua
+battery_widget {
+    -- Show different prefixes when charging on AC
+    ac_prefix = {
+        { 25, "not charged" },
+        { 50, "1/4 charged" },
+        { 75, "2/4 charged" },
+        { 95, "3/4 charged" },
+        {100, "fully charged" }
+    },
+
+    -- Show a visual indicator of charge level when on battery power
+    battery_prefix = {
+        { 25, "#--- "},
+        { 50, "##-- "},
+        { 75, "###- "},
+        {100, "#### "}
+    }
+}
+```
+
+`ac_prefix`, `battery_prefix`, and `widget_text` can be further customised with spans, e.g.:
 
 ```lua
 battery_widget {

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The pointer located inside of `/sys/class/power_supply` which corresponds to you
 The prefix to populate `${AC_BAT}` when your computer is using ac power. If your font supports unicode characters, you could use "🔌".
 
 `battery_prefix`
-The prefix to populate `${AC_BAT}` when your computer is using battery power. If your font supports unicode characters, you could use "🔋".
+The prefix to populate `${AC_BAT}` when your computer is using battery power. If your font supports unicode characters, you could use "🔋". Can also be configured as a table like `limits` to show different prefixes at different battery percentages.
 
 `limits`
 The colors that the percentage changes to, as well as the upper-bound limit of when it will change. Ex. `{100, "green"}` means any percentage lower than 100 is colored green.

--- a/battery-widget.lua
+++ b/battery-widget.lua
@@ -130,7 +130,7 @@ function battery_widget:init(args)
     self.adapter = args.adapter or "BAT0"
     self.ac_prefix = args.ac_prefix or "AC: "
     self.battery_prefix = args.battery_prefix or "Bat: "
-    self.limits = args.limits or {
+    self.percent_colors = args.percent_colors or args.limits or {
         { 25, "red"   },
         { 50, "orange"},
         {100, "green" }
@@ -223,7 +223,7 @@ function battery_widget:update()
                    or "Err!")
 
     -- Colors
-    ctx.color_on, ctx.color_off = color_tags(choose_by_percent(self.limits, ctx.percent))
+    ctx.color_on, ctx.color_off = color_tags(choose_by_percent(self.percent_colors, ctx.percent))
 
     -- estimate time
     ctx.charge_dir = 0    -- +1|0|-1 -> charging|static|discharging

--- a/battery-widget.lua
+++ b/battery-widget.lua
@@ -202,7 +202,24 @@ function battery_widget:update()
     if not ctx then return nil end
 
     -- AC/battery prefix
-    ctx.AC_BAT  = ctx.ac_state == 1 and self.ac_prefix or self.battery_prefix
+    ctx.AC_BAT  = ctx.ac_state == 1 and self.ac_prefix
+    if not ctx.AC_BAT then
+        if type(self.battery_prefix) == "table" then
+            if ctx.percent then
+                for k, v in ipairs(self.battery_prefix) do
+                    if ctx.percent <= v[1] then
+                        ctx.AC_BAT = v[2]
+                        break
+                    end
+                end
+            end
+            if not ctx.AC_BAT then
+                ctx.AC_BAT = "Err!"
+            end
+        else
+            ctx.AC_BAT = self.battery_prefix
+        end
+    end
 
     -- Colors
     ctx.color_on = ""


### PR DESCRIPTION
Combined with an icon font, this can be used to show different battery percentages as different icons. Can also be used to show, for example, a "Low bat:" prefix at low percentage and a "Bat: " prefix the rest of the time.

Does the README.md description referencing 'limits' suffice or should it have a code example?