### PR TITLE
Add timeout when watching for acpi_listen events

### DIFF
--- a/battery-widget.lua
+++ b/battery-widget.lua
@@ -166,7 +166,7 @@ function battery_widget:init(args)
     self:update()
 
     if (args.listen or args.listen == nil) and watch then
-        self.listener = watch("acpi_listen", {
+        self.listener = watch("acpi_listen", args.timeout, {
             stdout = function(line) self:update() end,
         })
         awesome.connect_signal("exit", function()


### PR DESCRIPTION
When not on AC, acpi_listen might emit multiple events per second triggering
multiple update() calls, which is bad for battery life itself.