### PR TITLE
Fix typo that leads to nil error in some cases

### DIFF
--- a/battery-widget.lua
+++ b/battery-widget.lua
@@ -108,7 +108,7 @@ function battery_widget:new(args)
     end
     -- creates an empty container wibox, which can be added to your panel even if its empty
     local widgets = { layout = wibox.layout.fixed.horizontal }
-    local batteries, mains, usb, usp = self:discover()
+    local batteries, mains, usb, ups = self:discover()
     local ac = mains[1] or usb[1] or ups[1]
     for i, adapter in ipairs(batteries) do
         local _args = setmetatable({adapter = adapter, ac = ac}, {__index = args})


### PR DESCRIPTION
Fixed a typo that leads to a nil error on desktop computers without a battery.
So I couldn't use the same awesome config on multiple devices.